### PR TITLE
WIP: DNM: Update to use text based impacts and description sub-sections

### DIFF
--- a/controls/cis-aws-foundations-1.1.rb
+++ b/controls/cis-aws-foundations-1.1.rb
@@ -1,20 +1,20 @@
-control "cis-aws-foundations-1.1" do
+control 'cis-aws-foundations-1.1' do
   title "Avoid the use of the 'root' account"
   desc  "The 'root' account has unrestricted access to all resources in the AWS
 account. It is highly recommended that the use of this account be avoided."
-  impact 0.3
-  tag "rationale": "The 'root' account is the most privileged AWS account.
+  impact 'low'
+  desc 'rationale', "The 'root' account is the most privileged AWS account.
 Minimizing the use of this account and adopting the principle of least
 privilege for access management will reduce the risk of accidental changes and
 unintended disclosure of highly privileged credentials."
-  tag "cis_impact": ""
-  tag "cis_rid": "1.1"
+  tag "cis_impact": ''
+  tag "cis_rid": '1.1'
   tag "cis_level": 1
-  tag "csc_control": [["5.1"], "6.0"]
-  tag "nist": ["AC-6 (9)", "Rev_4"]
-  tag "cce_id": ""
+  tag "csc_control": [['5.1'], '6.0']
+  tag "nist": ['AC-6 (9)', 'Rev_4']
+  tag "cce_id": ''
 
-  tag "check": "Implement the Ensure a log metric filter and alarm exist for
+  desc 'check', "Implement the Ensure a log metric filter and alarm exist for
 usage of 'root' account recommendation in the Monitoring section of this
 benchmark to receive notifications of root account usage. Additionally,
 executing the following commands will provide ad-hoc means for determining the
@@ -25,7 +25,7 @@ cut -d, -f1,5,11,16 | grep -B1 '<root_account>'
 'Note: there are a few conditions under which the use of the root account is
 required, such as requesting a penetration test or creating a CloudFront
 private key."
-  tag "fix": "Follow the remediation instructions of the Ensure IAM policies
+  desc 'fix', "Follow the remediation instructions of the Ensure IAM policies
 are attached only to groups or roles recommendation"
 
   describe aws_cloudtrail_trails do
@@ -34,31 +34,33 @@ are attached only to groups or roles recommendation"
 
   describe.one do
     aws_cloudtrail_trails.trail_arns.each do |trail|
-      trail_log_group_name = aws_cloudtrail_trail(trail).cloud_watch_logs_log_group_arn.scan( /log-group:(.+):/ ).last.first unless aws_cloudtrail_trail(trail).cloud_watch_logs_log_group_arn.nil?
+      trail_log_group_name = aws_cloudtrail_trail(trail).cloud_watch_logs_log_group_arn.scan(/log-group:(.+):/).last.first unless aws_cloudtrail_trail(trail).cloud_watch_logs_log_group_arn.nil?
 
       pattern = '{ $.userIdentity.type = "Root" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != "AwsServiceEvent" }'
 
       describe aws_cloudwatch_log_metric_filter(pattern: pattern, log_group_name: trail_log_group_name) do
-        it { should exist}
+        it { should exist }
       end
 
       metric_name = aws_cloudwatch_log_metric_filter(pattern: pattern, log_group_name: trail_log_group_name).metric_name
       metric_namespace = aws_cloudwatch_log_metric_filter(pattern: pattern, log_group_name: trail_log_group_name).metric_namespace
-      unless metric_name.nil? && metric_namespace.nil?
-        describe aws_cloudwatch_alarm(
-          metric_name: metric_name,
-          metric_namespace: metric_namespace ) do
-          it { should exist }
-          its ('alarm_actions') { should_not be_empty }
-        end
+      next if metric_name.nil? && metric_namespace.nil?
 
-        aws_cloudwatch_alarm(
-          metric_name: metric_name,
-          metric_namespace: metric_namespace).alarm_actions.each do |sns|
-          describe aws_sns_topic(sns) do
-            it { should exist }
-            its('confirmed_subscription_count') { should_not be_zero }
-          end
+      describe aws_cloudwatch_alarm(
+        metric_name: metric_name,
+        metric_namespace: metric_namespace
+      ) do
+        it { should exist }
+        its ('alarm_actions') { should_not be_empty }
+      end
+
+      aws_cloudwatch_alarm(
+        metric_name: metric_name,
+        metric_namespace: metric_namespace
+      ).alarm_actions.each do |sns|
+        describe aws_sns_topic(sns) do
+          it { should exist }
+          its('confirmed_subscription_count') { should_not be_zero }
         end
       end
     end

--- a/controls/cis-aws-foundations-1.10.rb
+++ b/controls/cis-aws-foundations-1.10.rb
@@ -3,8 +3,8 @@ control "cis-aws-foundations-1.10" do
   desc  "IAM password policies can prevent the reuse of a given password by the
 same user. It is recommended that the password policy prevent the reuse of
 passwords."
-  impact 0.3
-  tag "rationale": "Preventing password reuse increases account resiliency
+  impact 'low'
+  desc 'rationale', "Preventing password reuse increases account resiliency
 against brute force login attempts."
   tag "cis_impact": ""
   tag "cis_rid": "1.10"
@@ -12,7 +12,7 @@ against brute force login attempts."
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78908-1"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via AWS Console
@@ -29,7 +29,7 @@ Management Account Settings)
 'aws iam get-account-password-policy
 
 Ensure the output of the above command includes 'PasswordReusePrevention': 24"
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via AWS Console
 

--- a/controls/cis-aws-foundations-1.11.rb
+++ b/controls/cis-aws-foundations-1.11.rb
@@ -5,8 +5,8 @@ control "cis-aws-foundations-1.11" do
   desc  "IAM password policies can require passwords to be rotated or expired
 after a given number of days. It is recommended that the password policy expire
 passwords after #{AWS_CRED_AGE} days or less."
-  impact 0.3
-  tag "rationale": "Reducing the password lifetime increases account resiliency
+  impact 'low'
+  desc 'rationale', "Reducing the password lifetime increases account resiliency
 against brute force login attempts. Additionally, requiring regular password
 changes help in the following scenarios:
 
@@ -25,7 +25,7 @@ personal.
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78909-9"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via AWS Console:
@@ -42,7 +42,7 @@ Management Account Settings)
 'aws iam get-account-password-policy
 
 Ensure the output of the above command includes 'MaxPasswordAge': #{AWS_CRED_AGE} or less"
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via AWS Console:
 

--- a/controls/cis-aws-foundations-1.12.rb
+++ b/controls/cis-aws-foundations-1.12.rb
@@ -3,8 +3,8 @@ control "cis-aws-foundations-1.12" do
   desc  "The root account is the most privileged user in an AWS account. AWS
 Access Keys provide programmatic access to a given AWS account. It is
 recommended that all access keys associated with the root account be removed."
-  impact 0.3
-  tag "rationale": "Removing access keys associated with the root account
+  impact 'low'
+  desc 'rationale', "Removing access keys associated with the root account
 limits vectors by which the account can be compromised. Additionally, removing
 the root access keys encourages the creation and use of role based accounts
 that are least privileged."
@@ -14,7 +14,7 @@ that are least privileged."
   tag "csc_control": [["5.1"], "6.0"]
   tag "nist": ["AC-6(9)", "Rev_4"]
   tag "cce_id": "CCE-78910-7"
-  tag "check": "Perform the following to determine if the root account has
+  desc 'check', "Perform the following to determine if the root account has
 access keys:
 
 'Via the AWS Console
@@ -37,7 +37,7 @@ aws iam get-credential-report --query 'Content' --output text | base64 -d | cut
 -d, -f1,9,14 | grep -B1 '<root_account>'
 * For the <root_account> user, ensure the access_key_1_active and
 access_key_2_active fields are set to FALSE."
-  tag "fix": "Perform the following to delete or disable active root access
+  desc 'fix',"Perform the following to delete or disable active root access
 keys being
 
 'Via the AWS Console

--- a/controls/cis-aws-foundations-1.13.rb
+++ b/controls/cis-aws-foundations-1.13.rb
@@ -12,8 +12,8 @@ device used is NOT a personal device, but rather a dedicated mobile device
 any individual personal devices. ('non-personal virtual MFA') This lessens the
 risks of losing access to the MFA due to device loss, device trade-in or if the
 individual owning the device is no longer employed at the company."
-  impact 0.3
-  tag "rationale": "Enabling MFA provides increased security for console access
+  impact 'low'
+  desc 'rationale', "Enabling MFA provides increased security for console access
 as it requires the authenticating principal to possess a device that emits a
 time-sensitive key and have knowledge of a credential."
   tag "cis_impact": ""
@@ -22,7 +22,7 @@ time-sensitive key and have knowledge of a credential."
   tag "csc_control": [["5.6", "11.4", "12.6", "16.11"], "6.0"]
   tag "nist": ["IA-2(1)","SC-23", "Rev_4"]
   tag "cce_id": "CCE-78911-5"
-  tag "check": "Perform the following to determine if the root account has MFA
+  desc 'check', "Perform the following to determine if the root account has MFA
 setup:
 
 
@@ -33,7 +33,7 @@ setup:
 
 
 "
-  tag "fix": "Perform the following to establish MFA for the root account:
+  desc 'fix',"Perform the following to establish MFA for the root account:
 
 
  'Sign in to the AWS Management Console and open the IAM console at

--- a/controls/cis-aws-foundations-1.14.rb
+++ b/controls/cis-aws-foundations-1.14.rb
@@ -7,7 +7,7 @@ their user name and password as well as for an authentication code from their
 AWS MFA device. For Level 2, it is recommended that the root account be
 protected with a hardware MFA."
   impact 0.7
-  tag "rationale": "A hardware MFA has a smaller attack surface than a virtual
+  desc 'rationale', "A hardware MFA has a smaller attack surface than a virtual
 MFA. For example, a hardware MFA does not suffer the attack surface introduced
 by the mobile smartphone on which a virtual MFA resides.
 
@@ -24,7 +24,7 @@ http://onlinenoram.gemalto.com/ [http://onlinenoram.gemalto.com/]"
   tag "csc_control": [["5.6", "11.4", "12.6", "16.11"], "6.0"]
   tag "nist": ["IA-2(1)","SC-23", "Rev_4"]
   tag "cce_id": "CCE-78911-5"
-  tag "check": "Perform the following to determine if the root account has a
+  desc 'check', "Perform the following to determine if the root account has a
 hardware MFA setup:
 
 
@@ -38,7 +38,7 @@ recommendation:
 ' 'SerialNumber':
 'arn:aws:iam::_<aws_account_number>_:mfa/root-account-mfa-device'
 "
-  tag "fix": "Perform the following to establish a hardware MFA for the root
+  desc 'fix',"Perform the following to establish a hardware MFA for the root
 account:
 
 

--- a/controls/cis-aws-foundations-1.15.rb
+++ b/controls/cis-aws-foundations-1.15.rb
@@ -3,8 +3,8 @@ control "cis-aws-foundations-1.15" do
   desc  "The AWS support portal allows account owners to establish security
 questions that can be used to authenticate individuals calling AWS customer
 service for support. It is recommended that security questions be established."
-  impact 0.3
-  tag "rationale": "When creating a new AWS account, a default super user is
+  impact 'low'
+  desc 'rationale', "When creating a new AWS account, a default super user is
 automatically created. This account is referred to as the 'root' account. It is
 recommended that the use of this account be limited and highly controlled.
 During events in which the Root password is no longer accessible or the MFA
@@ -17,7 +17,7 @@ login access."
   tag "cis_control_number": ""
   tag "nist": ["IA-2", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Perform the following in the AWS Management Console:
+  desc 'check', "Perform the following in the AWS Management Console:
 
 * Login to the AWS account as root
 * On the top right you will see the _<Root_Account_Name>_
@@ -26,7 +26,7 @@ login access."
 * In the Configure Security Challenge Questions section on the Personal
 Information page, configure three security challenge questions.
 * Click Save questions."
-  tag "fix": "Perform the following in the AWS Management Console:
+  desc 'fix',"Perform the following in the AWS Management Console:
 
 * Login to the AWS Account as root
 * Click on the _<Root_Account_Name>_ from the top right of the console

--- a/controls/cis-aws-foundations-1.16.rb
+++ b/controls/cis-aws-foundations-1.16.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-1.16" do
 resources. IAM policies are the means by which privileges are granted to users,
 groups, or roles. It is recommended that IAM policies be applied directly to
 groups and roles but not users."
-  impact 0.3
-  tag "rationale": "Assigning privileges at the group or role level reduces the
+  impact 'low'
+  desc 'rationale', "Assigning privileges at the group or role level reduces the
 complexity of access management as the number of users grow. Reducing access
 management complexity may in-turn reduce opportunity for a principal to
 inadvertently receive or retain excessive privileges."
@@ -15,7 +15,7 @@ inadvertently receive or retain excessive privileges."
   tag "csc_control": ""
   tag "nist": ["AC-6(7)", "Rev_4"]
   tag "cce_id": "CCE-78912-3"
-  tag "check": "Perform the following to determine if policies are attached
+  desc 'check', "Perform the following to determine if policies are attached
 directly to users:
 
 * Run the following to get a list of IAM users:
@@ -28,7 +28,7 @@ policies are attached to them:
 'aws iam list-attached-user-policies --user-name <_iam_user_>
 aws iam list-user-policies --user-name _<iam_user>_
 * If any policies are returned, the user has a direct policy attachment."
-  tag "fix": "Perform the following to create an IAM group and assign a policy
+  desc 'fix',"Perform the following to create an IAM group and assign a policy
 to it:
 
  'Sign in to the AWS Management Console and open the IAM console at

--- a/controls/cis-aws-foundations-1.17.rb
+++ b/controls/cis-aws-foundations-1.17.rb
@@ -5,8 +5,8 @@ every event or hourly ongoing activity which incurs cost in an AWS account.
 These records are aggregated into CSV files of hourly records, and written to
 an S3 bucket. A CSV (Comma Separated Values) file of billing records is written
 at least every 24 hours; writing of files is often more frequent."
-  impact 0.3
-  tag "rationale": "Detailed Billing records can be used as an overview of AWS
+  impact 'low'
+  desc 'rationale', "Detailed Billing records can be used as an overview of AWS
 activity across the whole of an account, in addition to per-Region CloudTrail,
 Config and other service-specific JSON-based logs. Billing records can be
 graphed over time using the Cost Explorer tool, and budgeting alerts can be
@@ -23,7 +23,7 @@ occurring in."
   tag "csc_control": ""
   tag "nist": ["AU-12", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "There is currently no AWS CLI support for this operation, so it
+  desc 'check', "There is currently no AWS CLI support for this operation, so it
 is necessary to use the Management Console.
 
 As a user with IAM permission to read billing information
@@ -34,7 +34,7 @@ Management console at https://console.aws.amazon.com/billing/home#/.
 * On the navigation pane, choose Preferences.
 * Verify whether the 'Receive Billing Reports' check box is ticked. If it is
 not, billing reports are not being generated."
-  tag "fix": "There is currently no AWS CLI support for this operation, so it
+  desc 'fix',"There is currently no AWS CLI support for this operation, so it
 is necessary to use the Management Console.
 
 'As a user with IAM permission to read and write billing information

--- a/controls/cis-aws-foundations-1.18.rb
+++ b/controls/cis-aws-foundations-1.18.rb
@@ -25,8 +25,8 @@ also be assigned to EC2 instances and Lambda functions.
 Control over IAM, which is also defined and mediated by a number of
 fine-grained permissions, should be divided between a number of roles, such
 that no individual user in a production account has full control over IAM."
-  impact 0.3
-  tag "rationale": "IAM is the principal point of control for service
+  impact 'low'
+  desc 'rationale', "IAM is the principal point of control for service
 configuration access, and 'control over IAM' means 'control over the
 configuration of all other assets in the AWS account'. Therefore it is
 recommended that control of this degree of security criticality should be
@@ -57,7 +57,7 @@ manner, in order for a user to gain access to a permission."
   tag "csc_control": ""
   tag "nist": ["AC-6(7)", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Using the Amazon unified CLI, from a user or role which has the
+  desc 'check', "Using the Amazon unified CLI, from a user or role which has the
 iam:ListRoles and iam:GetRolePolicy permissions:
 
 List the configured roles:
@@ -196,7 +196,7 @@ Each role needs to be assumable by at least one user or group:
 'should display the AssumeRolePolicyDocument indicating which users and groups
 are able to assume the roles. No user or group should be able to assume both
 roles."
-  tag "fix": "Using the Amazon unified CLI, from a user or role which has the
+  desc 'fix',"Using the Amazon unified CLI, from a user or role which has the
 iam:CreateRole, iam:CreatePolicy and iam:PutRolePolicy permissions:
 
 'aws iam create-role --role-name _<iam_manager_role_name>_

--- a/controls/cis-aws-foundations-1.19.rb
+++ b/controls/cis-aws-foundations-1.19.rb
@@ -11,8 +11,8 @@ may arise where that individual is unavailable. Email contact details should
 point to a mail alias which forwards email to multiple individuals within the
 organisation; where feasible, phone contact details should point to a PABX hunt
 group or other call-forwarding system."
-  impact 0.3
-  tag "rationale": "If an AWS account is observed to be behaving in a
+  impact 'low'
+  desc 'rationale', "If an AWS account is observed to be behaving in a
 prohibited or suspicious manner, AWS will attempt to contact the account owner
 by email and phone using the contact details listed. If this is unsuccessful
 and the account behaviour needs urgent mitigation, proactive measures may be
@@ -29,7 +29,7 @@ aliases and PABX hunt groups."
   tag "csc_control": ""
   tag "nist": ["IA-4", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "This activity can only be performed via the AWS Console, with a
+  desc 'check', "This activity can only be performed via the AWS Console, with a
 user who has permission to read and write Billing information
 (aws-portal:*Billing ).
 
@@ -39,7 +39,7 @@ Management console at https://console.aws.amazon.com/billing/home#/.
 
 * On the Account Settings page, review and verify the current details.
 * Under Contact Information, review and verify the current details."
-  tag "fix": "This activity can only be performed via the AWS Console, with a
+  desc 'fix',"This activity can only be performed via the AWS Console, with a
 user who has permission to read and write Billing information
 (aws-portal:*Billing ).
 

--- a/controls/cis-aws-foundations-1.2.rb
+++ b/controls/cis-aws-foundations-1.2.rb
@@ -1,4 +1,4 @@
-control "cis-aws-foundations-1.2" do
+control 'cis-aws-foundations-1.2' do
   title "Ensure multi-factor authentication (MFA) is enabled for all IAM users
 that have a console password"
   desc  "Multi-Factor Authentication (MFA) adds an extra layer of protection on
@@ -6,17 +6,17 @@ top of a user name and password. With MFA enabled, when a user signs in to an
 AWS website, they will be prompted for their user name and password as well as
 for an authentication code from their AWS MFA device. It is recommended that
 MFA be enabled for all accounts that have a console password."
-  impact 0.3
-  tag "rationale": "Enabling MFA provides increased security for console access
+  impact 'low'
+  desc 'rationale', "Enabling MFA provides increased security for console access
 as it requires the authenticating principal to possess a device that emits a
 time-sensitive key and have knowledge of a credential."
-  tag "cis_impact": ""
-  tag "cis_rid": "1.2"
+  tag "cis_impact": ''
+  tag "cis_rid": '1.2'
   tag "cis_level": 1
-  tag "csc_control": [["5.6", "11.4", "12.6", "16.11"], "6.0"]
-  tag "nist": ["IA-2(1)","SC-23", "Rev_4"]
-  tag "cce_id": "CCE-78901-6"
-  tag "check": "Perform the following to determine if a MFA device is enabled
+  tag "csc_control": [['5.6', '11.4', '12.6', '16.11'], '6.0']
+  tag "nist": ['IA-2(1)', 'SC-23', 'Rev_4']
+  tag "cce_id": 'CCE-78901-6'
+  desc 'check', "Perform the following to determine if a MFA device is enabled
 for all IAM users having a console password:
 Via Management Console
 
@@ -59,7 +59,7 @@ set to true.
 
 
 "
-  tag "fix": "Perform the following to enable MFA:
+  desc 'fix', "Perform the following to enable MFA:
 
 
  'Sign in to the AWS Management Console and open the IAM console at
@@ -122,5 +122,4 @@ enrollment before active enforcement on existing AWS accounts.
   describe aws_iam_users.where(has_console_password?: true).where(has_mfa_enabled?: false) do
     it { should_not exist }
   end
-
 end

--- a/controls/cis-aws-foundations-1.20.rb
+++ b/controls/cis-aws-foundations-1.20.rb
@@ -3,8 +3,8 @@ control "cis-aws-foundations-1.20" do
   desc  "AWS provides customers with the option of specifying the contact
 information for account's security team. It is recommended that this
 information be provided."
-  impact 0.3
-  tag "rationale": "Specifying security-specific contact information will help
+  impact 'low'
+  desc 'rationale', "Specifying security-specific contact information will help
 ensure that security advisories sent by AWS reach the team in your organization
 that is best equipped to respond to them."
   tag "cis_impact": ""
@@ -13,14 +13,14 @@ that is best equipped to respond to them."
   tag "csc_control": ""
   tag "nist": ["IA-4", "Rev_4"]
   tag "cce_id": "CCE-79200-2"
-  tag "check": "Perform the following in the AWS Management Console to
+  desc 'check', "Perform the following in the AWS Management Console to
 determine if security contact information is present:
 
 * Click on your account name at the top right corner of the console
 * From the drop-down menu Click My Account
 * Scroll down to the Alternate Contacts section
 * Ensure contact information is specified in the Security section"
-  tag "fix": "Perform the following in the AWS Management Console to establish
+  desc 'fix',"Perform the following in the AWS Management Console to establish
 security contact information:
 
 * Click on your account name at the top right corner of the console.

--- a/controls/cis-aws-foundations-1.21.rb
+++ b/controls/cis-aws-foundations-1.21.rb
@@ -7,7 +7,7 @@ appropriate permissions policy for the required access. 'AWS Access' means
 accessing the APIs of AWS in order to access AWS resources or manage AWS
 account resources."
   impact 0.7
-  tag "rationale": "AWS IAM roles reduce the risks associated with sharing and
+  desc 'rationale', "AWS IAM roles reduce the risks associated with sharing and
 rotating credentials that can be used outside of AWS itself. If credentials are
 compromised, they can be used from outside of the the AWS account they give
 access to. In contrast, in order to leverage role permissions an attacker would
@@ -25,7 +25,7 @@ individuals who no longer work for the organization owning the credentials."
   tag "csc_control": [["16.14"], "6.0"]
   tag "nist": ["SC-28", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Whether an Instance Is Associated With a Role
+  desc 'check', "Whether an Instance Is Associated With a Role
 
 'For instances that are known to perform AWS actions, ensure that they belong
 to an instance role that has the necessary permissions:
@@ -53,7 +53,7 @@ determined by eliminating all other sources of credentials and if the
 application can still access AWS resources - it likely contains embedded
 credentials. Another method is to examine all source code and configuration
 files of the application."
-  tag "fix": "IAM roles can only be associated at the launch of an instance. To
+  desc 'fix',"IAM roles can only be associated at the launch of an instance. To
 remediate an instance to add it to a role you must create a new instance.
 
 'If the instance has no external dependencies on it's current private ip or

--- a/controls/cis-aws-foundations-1.22.rb
+++ b/controls/cis-aws-foundations-1.22.rb
@@ -5,8 +5,8 @@ Support"
 notification and response, as well as technical support and customer services.
 Create an IAM Role to allow authorized users to manage incidents with AWS
 Support."
-  impact 0.3
-  tag "rationale": "By implementing least privilege for access control, an IAM
+  impact 'low'
+  desc 'rationale', "By implementing least privilege for access control, an IAM
 Role will require an appropriate IAM Policy to allow Support Center Access in
 order to manage Incidents with AWS Support."
   tag "cis_impact": "All AWS Support plans include an unlimited number of
@@ -23,7 +23,7 @@ month's AWS usage charges, subject to a monthly minimum, billed in advance."
   tag "csc_control": ""
   tag "nist": ["IR-7", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Using the Amazon unified command line interface:
+  desc 'check', "Using the Amazon unified command line interface:
 
 * List IAM policies, filter for the 'AWSSupportAccess' managed policy, and note
 the 'Arn' element value:
@@ -35,7 +35,7 @@ the 'Arn' element value:
 
  'aws iam list-entities-for-policy --policy-arn <iam_policy_arn>
 "
-  tag "fix": "Using the Amazon unified command line interface:
+  desc 'fix',"Using the Amazon unified command line interface:
 
 * Create an IAM role for managing incidents with AWS:
 

--- a/controls/cis-aws-foundations-1.23.rb
+++ b/controls/cis-aws-foundations-1.23.rb
@@ -5,8 +5,8 @@ that have a console password"
 This results in many access keys being generated unnecessarily. In addition to
 unnecessary credentials, it also generates unnecessary management work in
 auditing and rotating these keys."
-  impact 0.3
-  tag "rationale": "Requiring that additional steps be taken by the user after
+  impact 'low'
+  desc 'rationale', "Requiring that additional steps be taken by the user after
 their profile has been created will give a stronger indication of intent that
 access keys are [a] necessary for their work and [b] once the access key is
 established on an account, that the keys may be in use somewhere in the
@@ -21,7 +21,7 @@ separate step from user creation."
   tag "csc_control": ""
   tag "nist": ["AC-6", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Perform the following to determine if access keys are rotated
+  desc 'check', "Perform the following to determine if access keys are rotated
 as prescribed:
 
 * Login to the AWS Management Console
@@ -60,7 +60,7 @@ key is deleted.
 
 
 "
-  tag "fix": "Perform the following to delete access keys that do not pass the
+  desc 'fix',"Perform the following to delete access keys that do not pass the
 audit:
 
 * Login to the AWS Management Console:

--- a/controls/cis-aws-foundations-1.24.rb
+++ b/controls/cis-aws-foundations-1.24.rb
@@ -7,8 +7,8 @@ to grant _least privilege_--that is, granting only the permissions required to
 perform a task. Determine what users need to do and then craft policies for
 them that let the users perform _only_ those tasks, instead of allowing full
 administrative privileges."
-  impact 0.3
-  tag "rationale": "It's more secure to start with a minimum set of permissions
+  impact 'low'
+  desc 'rationale', "It's more secure to start with a minimum set of permissions
 and grant additional permissions as necessary, rather than starting with
 permissions that are too lenient and then trying to tighten them later.
 
@@ -25,7 +25,7 @@ over  'Resource': '*' should be removed."
   tag "csc_control": ""
   tag "nist": ["AC-6", "Rev_4"]
   tag "cce_id": "CCE-78912-3"
-  tag "check": "Perform the following to determine what policies are created:
+  desc 'check', "Perform the following to determine what policies are created:
 
 * Run the following to get a list of IAM policies:
 
@@ -38,7 +38,7 @@ policies is allowing full administrative privileges on the account:
 _<policy_version>_ --query 'PolicyVersion.Document.Statement[?Effect == 'Allow'
 && contains(Resource, '*') && contains (Action, '*')]'
 * If the output of the command returns any policies, it's not compliant."
-  tag "fix": "Using the GUI, perform the following to detach the policy that
+  desc 'fix',"Using the GUI, perform the following to detach the policy that
 has full administrative privileges:
 
  'Sign in to the AWS Management Console and open the IAM console at

--- a/controls/cis-aws-foundations-1.3.rb
+++ b/controls/cis-aws-foundations-1.3.rb
@@ -1,20 +1,20 @@
-control "cis-aws-foundations-1.3" do
-  title "Ensure credentials unused for 90 days or greater are disabled"
+control 'cis-aws-foundations-1.3' do
+  title 'Ensure credentials unused for 90 days or greater are disabled'
   desc  "AWS IAM users can access AWS resources using different types of
 credentials, such as passwords or access keys. It is recommended that all
 credentials that have been unused in 90 or greater days be removed or
 deactivated."
-  impact 0.3
-  tag "rationale": "Disabling or removing unnecessary credentials will reduce
+  impact 'low'
+  desc 'rationale', "Disabling or removing unnecessary credentials will reduce
 the window of opportunity for credentials associated with a compromised or
 abandoned account to be used."
-  tag "cis_impact": ""
-  tag "cis_rid": "1.3"
+  tag "cis_impact": ''
+  tag "cis_rid": '1.3'
   tag "cis_level": 1
-  tag "csc_control": [["16.6"], "6.0"]
-  tag "nist": ["IA-4", "Rev_4"]
-  tag "cce_id": "CCE-78900-8"
-  tag "check": "Perform the following to determine if unused credentials exist:
+  tag "csc_control": [['16.6'], '6.0']
+  tag "nist": ['IA-4', 'Rev_4']
+  tag "cce_id": 'CCE-78900-8'
+  desc 'check', "Perform the following to determine if unused credentials exist:
 
 
 * Login to the AWS Management Console
@@ -40,7 +40,7 @@ aws iam get-credential-report --query 'Content' --output text | base64 -d | cut
 password_last_used_date is less than 90 days ago.
 * For each user having an access_key_1_active or access_key_2_active to TRUE,
 ensure the corresponding access_key_n_last_used_date is less than 90 days ago."
-  tag "fix": "Perform the following to remove or deactivate credentials:
+  desc 'fix', "Perform the following to remove or deactivate credentials:
 
 * Login to the AWS Management Console:
 * Click Services
@@ -61,7 +61,7 @@ ensure the corresponding access_key_n_last_used_date is less than 90 days ago."
     it { should_not exist }
   end
 
-  describe aws_iam_users.where(password_ever_used?: true).where{ password_last_used_days_ago >= 90 } do
+  describe aws_iam_users.where(password_ever_used?: true).where { password_last_used_days_ago >= 90 } do
     it { should_not exist }
   end
 
@@ -73,7 +73,9 @@ ensure the corresponding access_key_n_last_used_date is less than 90 days ago."
     end
   end
 
-  describe "Control skipped because no active iam access keys were found" do
-    skip "This control is skipped since the aws_iam_access_keys resource returned an empty active access key list"
-  end if aws_iam_access_keys.where(active: true).entries.empty?
+  if aws_iam_access_keys.where(active: true).entries.empty?
+    describe 'Control skipped because no active iam access keys were found' do
+      skip 'This control is skipped since the aws_iam_access_keys resource returned an empty active access key list'
+    end
+  end
 end

--- a/controls/cis-aws-foundations-1.4.rb
+++ b/controls/cis-aws-foundations-1.4.rb
@@ -8,8 +8,8 @@ their own access keys to make programmatic calls to AWS from the AWS Command
 Line Interface (AWS CLI), Tools for Windows PowerShell, the AWS SDKs, or direct
 HTTP calls using the APIs for individual AWS services. It is recommended that
 all access keys be regularly rotated."
-  impact 0.3
-  tag "rationale": "Rotating access keys will reduce the window of opportunity
+  impact 'low'
+  desc 'rationale', "Rotating access keys will reduce the window of opportunity
 for an access key that is associated with a compromised or terminated account
 to be used.
 
@@ -21,7 +21,7 @@ old key which might have been lost, cracked, or stolen."
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78902-4"
-  tag "check": "Perform the following to determine if access keys are rotated
+  desc 'check', "Perform the following to determine if access keys are rotated
 as prescribed:
 
 * Login to the AWS Management Console
@@ -48,7 +48,7 @@ users within an AWS Account - open this file
 
 'aws iam generate-credential-report
 aws iam get-credential-report --query 'Content' --output text | base64 -d"
-  tag "fix": "Perform the following to rotate access keys:
+  desc 'fix',"Perform the following to rotate access keys:
 
 * Login to the AWS Management Console:
 * Click Services

--- a/controls/cis-aws-foundations-1.5.rb
+++ b/controls/cis-aws-foundations-1.5.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-1.5" do
 requirements. IAM password policies can be used to ensure password are
 comprised of different character sets. It is recommended that the password
 policy require at least one uppercase letter."
-  impact 0.3
-  tag "rationale": "Setting a password complexity policy increases account
+  impact 'low'
+  desc 'rationale', "Setting a password complexity policy increases account
 resiliency against brute force login attempts."
   tag "cis_impact": ""
   tag "cis_rid": "1.5"
@@ -13,7 +13,7 @@ resiliency against brute force login attempts."
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78903-2"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via AWS Console
@@ -31,7 +31,7 @@ Policy'
 
 Ensure the output of the above command includes 'RequireUppercaseCharacters':
 true"
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via AWS Console
 

--- a/controls/cis-aws-foundations-1.6.rb
+++ b/controls/cis-aws-foundations-1.6.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-1.6" do
 requirements. IAM password policies can be used to ensure password are
 comprised of different character sets. It is recommended that the password
 policy require at least one lowercase letter."
-  impact 0.3
-  tag "rationale": "Setting a password complexity policy increases account
+  impact 'low'
+  desc 'rationale', "Setting a password complexity policy increases account
 resiliency against brute force login attempts."
   tag "cis_impact": ""
   tag "cis_rid": "1.6"
@@ -13,7 +13,7 @@ resiliency against brute force login attempts."
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78904-0"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via the AWS Console
@@ -31,7 +31,7 @@ Policy'
 
 Ensure the output of the above command includes 'RequireLowercaseCharacters':
 true"
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via the AWS Console
 

--- a/controls/cis-aws-foundations-1.7.rb
+++ b/controls/cis-aws-foundations-1.7.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-1.7" do
 requirements. IAM password policies can be used to ensure password are
 comprised of different character sets. It is recommended that the password
 policy require at least one symbol."
-  impact 0.3
-  tag "rationale": "Setting a password complexity policy increases account
+  impact 'low'
+  desc 'rationale', "Setting a password complexity policy increases account
 resiliency against brute force login attempts."
   tag "cis_impact": ""
   tag "cis_rid": "1.7"
@@ -13,7 +13,7 @@ resiliency against brute force login attempts."
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78905-7"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via AWS Console
@@ -30,7 +30,7 @@ Management Account Settings)
 'aws iam get-account-password-policy
 
 Ensure the output of the above command includes 'RequireSymbols': true"
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via AWS Console
 

--- a/controls/cis-aws-foundations-1.8.rb
+++ b/controls/cis-aws-foundations-1.8.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-1.8" do
 requirements. IAM password policies can be used to ensure password are
 comprised of different character sets. It is recommended that the password
 policy require at least one number."
-  impact 0.3
-  tag "rationale": "Setting a password complexity policy increases account
+  impact 'low'
+  desc 'rationale', "Setting a password complexity policy increases account
 resiliency against brute force login attempts."
   tag "cis_impact": ""
   tag "cis_rid": "1.8"
@@ -13,7 +13,7 @@ resiliency against brute force login attempts."
   tag "csc_control": ""
   tag "nist": ["IA-5(1)", "Rev_4"]
   tag "cce_id": "CCE-78906-5"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via AWS Console
@@ -29,7 +29,7 @@ Management Account Settings)
 'aws iam get-account-password-policy
 
 Ensure the output of the above command includes 'RequireNumbers': true"
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via AWS Console
 

--- a/controls/cis-aws-foundations-1.9.rb
+++ b/controls/cis-aws-foundations-1.9.rb
@@ -6,8 +6,8 @@ control "cis-aws-foundations-1.9" do
 requirements. IAM password policies can be used to ensure password are at least
 a given length. It is recommended that the password policy require a minimum
 password length #{PWD_LENGTH}."
-  impact 0.3
-  tag "rationale": "Setting a password complexity policy increases account
+  impact 'low'
+  desc 'rationale', "Setting a password complexity policy increases account
 resiliency against brute force login attempts."
   tag "cis_impact": ''
   tag "cis_rid": "1.9"
@@ -15,7 +15,7 @@ resiliency against brute force login attempts."
   tag "csc_control": [["5.7", "16.12"], "6.0"]
   tag "nist": ["IA-5(1)","IA-2", "Rev_4"]
   tag "cce_id": "CCE-78907-3"
-  tag "check": "Perform the following to ensure the password policy is
+  desc 'check', "Perform the following to ensure the password policy is
 configured as prescribed:
 
 'Via AWS Console
@@ -33,7 +33,7 @@ Management Account Settings)
 Ensure the output of the above command includes 'MinimumPasswordLength': #{PWD_LENGTH} (or
 higher)"
 
-  tag "fix": "Perform the following to set the password policy as prescribed:
+  desc 'fix',"Perform the following to set the password policy as prescribed:
 
 'Via AWS Console
 

--- a/controls/cis-aws-foundations-2.1.rb
+++ b/controls/cis-aws-foundations-2.1.rb
@@ -7,8 +7,8 @@ the API caller, the request parameters, and the response elements returned by
 the AWS service. CloudTrail provides a history of AWS API calls for an account,
 including API calls made via the Management Console, SDKs, command line tools,
 and higher-level AWS services (such as CloudFormation)."
-  impact 0.3
-  tag "rationale": "The AWS API call history produced by CloudTrail enables
+  impact 'low'
+  desc 'rationale', "The AWS API call history produced by CloudTrail enables
 security analysis, resource change tracking, and compliance auditing.
 Additionally, ensuring that a multi-regions trail exists will ensure that
 unexpected activity occurring in otherwise unused regions is detected."
@@ -22,7 +22,7 @@ for more information on these features:
   tag "csc_control": [["14.6"], "6.0"]
   tag "nist": ["AU-2", "Rev_4"]
   tag "cce_id": "CCE-78913-1"
-  tag "check": "Perform the following to determine if CloudTrail is enabled for
+  desc 'check', "Perform the following to determine if CloudTrail is enabled for
 all regions:
 
 'Via the management Console
@@ -47,7 +47,7 @@ https://console.aws.amazon.com/cloudtrail
 ' aws cloudtrail describe-trails
 
 'Ensure IsMultiRegionTrail is set to true"
-  tag "fix": "Perform the following to enable global CloudTrail logging:
+  desc 'fix',"Perform the following to enable global CloudTrail logging:
 
 'Via the management Console
 

--- a/controls/cis-aws-foundations-2.2.rb
+++ b/controls/cis-aws-foundations-2.2.rb
@@ -6,7 +6,7 @@ can be used to determine whether a log file was changed, deleted, or unchanged
 after CloudTrail delivered the log. It is recommended that file validation be
 enabled on all CloudTrails."
   impact 0.7
-  tag "rationale": "Enabling log file validation will provide additional
+  desc 'rationale', "Enabling log file validation will provide additional
 integrity checking of CloudTrail logs."
   tag "cis_impact": ""
   tag "cis_rid": "2.2"
@@ -14,7 +14,7 @@ integrity checking of CloudTrail logs."
   tag "csc_control": [["6.3"], "6.0"]
   tag "nist": ["AU-4", "Rev_4"]
   tag "cce_id": "CCE-78914-9"
-  tag "check": "Perform the following on each trail to determine if log file
+  desc 'check', "Perform the following on each trail to determine if log file
 validation is enabled:
 
 'Via the management Console
@@ -37,7 +37,7 @@ https://console.aws.amazon.com/cloudtrail
 'aws cloudtrail describe-trails
 
 'Ensure LogFileValidationEnabled is set to true for each trail."
-  tag "fix": "Perform the following to enable log file validation on a given
+  desc 'fix',"Perform the following to enable log file validation on a given
 trail:
 
 'Via the management Console

--- a/controls/cis-aws-foundations-2.3.rb
+++ b/controls/cis-aws-foundations-2.3.rb
@@ -6,8 +6,8 @@ control "cis-aws-foundations-2.3" do
 These logs file are stored in an S3 bucket. It is recommended that the bucket
 policy or access control list (ACL) applied to the S3 bucket that CloudTrail
 logs to prevents public access to the CloudTrail logs."
-  impact 0.3
-  tag "rationale": "Allowing public access to CloudTrail log content may aid an
+  impact 'low'
+  desc 'rationale', "Allowing public access to CloudTrail log content may aid an
 adversary in identifying weaknesses in the affected account's use or
 configuration."
   tag "cis_impact": ""
@@ -16,7 +16,7 @@ configuration."
   tag "csc_control": ""
   tag "nist": ["AU-9", "Rev_4"]
   tag "cce_id": "CCE-78915-6"
-  tag "check": "Perform the following to determine if any public access is
+  desc 'check', "Perform the following to determine if any public access is
 granted to an S3 bucket via an ACL or S3 bucket policy:
 
 'Via the Management Console
@@ -63,7 +63,7 @@ Users`]'
 'aws s3api get-bucket-policy --bucket <s3_bucket_for_cloudtrail>
 * Ensure the policy does not contain a Statement having an Effect set to Allow
 and a Principal set to *."
-  tag "fix": "Perform the following to remove any public access that has been
+  desc 'fix',"Perform the following to remove any public access that has been
 granted to the bucket via an ACL or S3 bucket policy:
 
 * Go to Amazon S3 console at https://console.aws.amazon.com/s3/home

--- a/controls/cis-aws-foundations-2.4.rb
+++ b/controls/cis-aws-foundations-2.4.rb
@@ -16,8 +16,8 @@ be sent to CloudWatch Logs.
 being captured, monitored, and appropriately alarmed on. CloudWatch Logs is a
 native way to accomplish this using AWS services but does not preclude the use
 of an alternate solution."
-  impact 0.3
-  tag "rationale": "Sending CloudTrail logs to CloudWatch Logs will facilitate
+  impact 'low'
+  desc 'rationale', "Sending CloudTrail logs to CloudWatch Logs will facilitate
 real-time and historic activity logging based on user, API, resource, and IP
 address, and provides opportunity to establish alarms and notifications for
 anomalous or sensitivity account activity."
@@ -38,7 +38,7 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/SettingLogRete
   tag "csc_control": [["6.6", "14.6"], "6.0"]
   tag "nist": ["SI-4(2)", "AU-2", "Rev_4"]
   tag "cce_id": "CCE-78916-4"
-  tag "check": "Perform the following to ensure CloudTrail is configured as
+  desc 'check', "Perform the following to ensure CloudTrail is configured as
 prescribed:
 
 'Via the AWS management Console
@@ -65,7 +65,7 @@ property.
 'aws cloudtrail get-trail-status --name _<trail_name>_
 * Ensure the LatestcloudwatchLogdDeliveryTime property is set to a recent (~one
 day old) timestamp."
-  tag "fix": "Perform the following to establish the prescribed state:
+  desc 'fix',"Perform the following to establish the prescribed state:
 
 'Via the AWS management Console
 

--- a/controls/cis-aws-foundations-2.5.rb
+++ b/controls/cis-aws-foundations-2.5.rb
@@ -8,8 +8,8 @@ recorded information includes the configuration item (AWS resource),
 relationships between configuration items (AWS resources), any configuration
 changes between resources. It is recommended to enable AWS Config be enabled in
 all regions."
-  impact 0.3
-  tag "rationale": "The AWS configuration item history captured by AWS Config
+  impact 'low'
+  desc 'rationale', "The AWS configuration item history captured by AWS Config
 enables security analysis, resource change tracking, and compliance auditing."
   tag "cis_impact": ""
   tag "cis_rid": "2.5"
@@ -17,7 +17,7 @@ enables security analysis, resource change tracking, and compliance auditing."
   tag "csc_control": [["1.1", "1.3", "1.4", "5.2", "11.1", "11.3", "14.6"], "6.0"]
   tag "nist": ["CM-8(3)", "CM-8(2)", "CM-8", "AC-6(7)", "CM-6(1)", "CM-6(2)", "AU-2", "Rev_4"]
   tag "cce_id": "CCE-78917-2"
-  tag "check": "Process to evaluate AWS Config configuration per region
+  desc 'check', "Process to evaluate AWS Config configuration per region
 
 'Via AWS Management Console
 
@@ -38,7 +38,7 @@ in 1 region only
 * Ensure the correct S3 bucket has been defined.
 * Ensure the correct SNS topic has been defined.
 * Repeat steps 2 to 7 for each region."
-  tag "fix": "Perform the following in the AWS Management Console:
+  desc 'fix',"Perform the following in the AWS Management Console:
 
 * Select the region you want to focus on in the top right of the console
 * Click Services

--- a/controls/cis-aws-foundations-2.6.rb
+++ b/controls/cis-aws-foundations-2.6.rb
@@ -7,8 +7,8 @@ for each request made to your S3 bucket. An access log record contains details
 about the request, such as the request type, the resources specified in the
 request worked, and the time and date the request was processed. It is
 recommended that bucket access logging be enabled on the CloudTrail S3 bucket."
-  impact 0.3
-  tag "rationale": "By enabling S3 bucket logging on target S3 buckets, it is
+  impact 'low'
+  desc 'rationale', "By enabling S3 bucket logging on target S3 buckets, it is
 possible to capture all events which may affect objects within an target
 buckets. Configuring logs to be placed in a separate bucket allows access to
 log information which can be useful in security and incident response
@@ -19,7 +19,7 @@ workflows."
   tag "csc_control": [["14.6"], "6.0"]
   tag "nist": ["AU-2", "Rev_4"]
   tag "cce_id": "CCE-78918-0"
-  tag "check": "Perform the following ensure the CloudTrail S3 bucket has
+  desc 'check', "Perform the following ensure the CloudTrail S3 bucket has
 access logging is enabled:
 
 'Via the management Console
@@ -39,7 +39,7 @@ https://console.aws.amazon.com/s3 [https://console.aws.amazon.com/s3].
 'Via CLI
 
 'aws s3api get-bucket-logging --bucket <s3_bucket_for_cloudtrail>"
-  tag "fix": "Perform the following to enable S3 bucket logging:
+  desc 'fix',"Perform the following to enable S3 bucket logging:
 
 'Via the Management Console
 

--- a/controls/cis-aws-foundations-2.7.rb
+++ b/controls/cis-aws-foundations-2.7.rb
@@ -9,7 +9,7 @@ keys. CloudTrail logs can be configured to leverage server side encryption
 (SSE) and KMS customer created master keys (CMK) to further protect CloudTrail
 logs. It is recommended that CloudTrail be configured to use SSE-KMS."
   impact 0.7
-  tag "rationale": "Configuring CloudTrail to use SSE-KMS provides additional
+  desc 'rationale', "Configuring CloudTrail to use SSE-KMS provides additional
 confidentiality controls on log data as a given user must have S3 read
 permission on the corresponding log bucket and must be granted decrypt
 permission by the CMK policy."
@@ -20,7 +20,7 @@ https://aws.amazon.com/kms/pricing/ for more information."
   tag "csc_control": [["13.1"], "6.0"]
   tag "nist": ["AU-9", "Rev_4"]
   tag "cce_id": "CCE-78919-8"
-  tag "check": "Perform the following to determine if CloudTrail is configured
+  desc 'check', "Perform the following to determine if CloudTrail is configured
 to use SSE-KMS:
 
 'Via the Management Console
@@ -40,7 +40,7 @@ is specified in the KSM Key Id field.
 'aws cloudtrail describe-trails
 * For each trail listed, SSE-KMS is enabled if the trail has a KmsKeyId
 property defined."
-  tag "fix": "Perform the following to configure CloudTrail to use SSE-KMS:
+  desc 'fix',"Perform the following to configure CloudTrail to use SSE-KMS:
 
 'Via the Management Console
 

--- a/controls/cis-aws-foundations-2.8.rb
+++ b/controls/cis-aws-foundations-2.8.rb
@@ -8,7 +8,7 @@ decryption. Automated key rotation currently retains all prior backing keys so
 that decryption of encrypted data can take place transparently. It is
 recommended that CMK key rotation be enabled."
   impact 0.7
-  tag "rationale": "Rotating encryption keys helps reduce the potential impact
+  desc 'rationale', "Rotating encryption keys helps reduce the potential impact
 of a compromised key as data encrypted with a new key cannot be accessed with a
 previous key that may have been exposed."
   tag "cis_impact": ""
@@ -17,7 +17,7 @@ previous key that may have been exposed."
   tag "csc_control": ""
   tag "nist": ["SC-12", "Rev_4"]
   tag "cce_id": "CCE-78920-6"
-  tag "check": "Via the Management Console:
+  desc 'check', "Via the Management Console:
 
 * Sign in to the AWS Management Console and open the IAM console at
 https://console.aws.amazon.com/iam [https://console.aws.amazon.com/iam].
@@ -38,7 +38,7 @@ KeyIds
 
 'aws kms get-key-rotation-status --key-id _<kms_key_id>_
 * Ensure KeyRotationEnabled is set to true"
-  tag "fix": "Via the Management Console:
+  desc 'fix',"Via the Management Console:
 
 * Sign in to the AWS Management Console and open the IAM console at
 https://console.aws.amazon.com/iam [https://console.aws.amazon.com/iam].

--- a/controls/cis-aws-foundations-3.1.rb
+++ b/controls/cis-aws-foundations-3.1.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-3.1" do
 CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for unauthorized API calls."
-  impact 0.3
-  tag "rationale": "Monitoring unauthorized API calls will help reveal
+  impact 'low'
+  desc 'rationale', "Monitoring unauthorized API calls will help reveal
 application errors and may reduce time to detect malicious activity."
   tag "cis_impact": "This alert may be triggered by normal read-only console
 activities that attempt to opportunistically gather optional information, but
@@ -23,7 +23,7 @@ the original limited IAM user intent."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79186-3"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed:
 1. Identify the log group name configured for use with CloudTrail:
 
@@ -61,7 +61,7 @@ _<unauthorized_api_calls_metric>_ captured in step 5.
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:
 1. Create a metric filter based on filter pattern provided which checks for
 unauthorized API calls and the <cloudtrail_log_group_name> taken from audit

--- a/controls/cis-aws-foundations-3.10.rb
+++ b/controls/cis-aws-foundations-3.10.rb
@@ -6,7 +6,7 @@ filters and alarms. Security Groups are a stateful packet filter that controls
 ingress and egress traffic within a VPC. It is recommended that a metric filter
 and alarm be established changes to Security Groups."
   impact 0.7
-  tag "rationale": "Monitoring changes to security group will help ensure that
+  desc 'rationale', "Monitoring changes to security group will help ensure that
 resources and services are not unintentionally exposed."
   tag "cis_impact": ""
   tag "cis_rid": "3.10"
@@ -14,7 +14,7 @@ resources and services are not unintentionally exposed."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79195-4"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -54,7 +54,7 @@ _<security_group_changes_metric>_ captured in step 5.
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for security groups changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.11.rb
+++ b/controls/cis-aws-foundations-3.11.rb
@@ -7,7 +7,7 @@ filters and alarms. NACLs are used as a stateless packet filter to control
 ingress and egress traffic for subnets within a VPC. It is recommended that a
 metric filter and alarm be established for changes made to NACLs."
   impact 0.7
-  tag "rationale": "Monitoring changes to NACLs will help ensure that AWS
+  desc 'rationale', "Monitoring changes to NACLs will help ensure that AWS
 resources and services are not unintentionally exposed."
   tag "cis_impact": ""
   tag "cis_rid": "3.11"
@@ -15,7 +15,7 @@ resources and services are not unintentionally exposed."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79196-2"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -55,7 +55,7 @@ captured in step 5.
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for NACL changes and the <cloudtrail_log_group_name>
 taken from audit step 2.

--- a/controls/cis-aws-foundations-3.12.rb
+++ b/controls/cis-aws-foundations-3.12.rb
@@ -6,8 +6,8 @@ CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. Network gateways are required to send/receive traffic to a
 destination outside of a VPC. It is recommended that a metric filter and alarm
 be established for changes to network gateways."
-  impact 0.3
-  tag "rationale": "Monitoring changes to network gateways will help ensure
+  impact 'low'
+  desc 'rationale', "Monitoring changes to network gateways will help ensure
 that all ingress/egress traffic traverses the VPC border via a controlled path."
   tag "cis_impact": ""
   tag "cis_rid": "3.12"
@@ -15,7 +15,7 @@ that all ingress/egress traffic traverses the VPC border via a controlled path."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79197-0"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -55,7 +55,7 @@ _<network_gw_changes_metric>_ captured in step 5.
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for network gateways changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.13.rb
+++ b/controls/cis-aws-foundations-3.13.rb
@@ -5,8 +5,8 @@ CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. Routing tables are used to route network traffic between
 subnets and to network gateways. It is recommended that a metric filter and
 alarm be established for changes to route tables."
-  impact 0.3
-  tag "rationale": "Monitoring changes to route tables will help ensure that
+  impact 'low'
+  desc 'rationale', "Monitoring changes to route tables will help ensure that
 all VPC traffic flows through an expected path."
   tag "cis_impact": ""
   tag "cis_rid": "3.13"
@@ -14,7 +14,7 @@ all VPC traffic flows through an expected path."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79198-8"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -54,7 +54,7 @@ _<route_table_changes_metric>_ captured in step 5.
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for route table changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.14.rb
+++ b/controls/cis-aws-foundations-3.14.rb
@@ -6,8 +6,8 @@ filters and alarms. It is possible to have more than 1 VPC within an account,
 in addition it is also possible to create a peer connection between 2 VPCs
 enabling network traffic to route between VPCs. It is recommended that a metric
 filter and alarm be established for changes made to VPCs."
-  impact 0.3
-  tag "rationale": "Monitoring changes to IAM policies will help ensure
+  impact 'low'
+  desc 'rationale', "Monitoring changes to IAM policies will help ensure
 authentication and authorization controls remain intact."
   tag "cis_impact": ""
   tag "cis_rid": "3.14"
@@ -15,7 +15,7 @@ authentication and authorization controls remain intact."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79199-6"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -58,7 +58,7 @@ _<unauthorized_api_calls_metric>_ captured in step 5.
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for VPC changes and the <cloudtrail_log_group_name> taken
 from audit step 2.

--- a/controls/cis-aws-foundations-3.15.rb
+++ b/controls/cis-aws-foundations-3.15.rb
@@ -9,8 +9,8 @@ updates to notify their subscribers about, they can publish a message to the
 topic - which immediately triggers Amazon SNS to deliver the message to all
 applicable subscribers. It is recommended that the list of subscribers to given
 topics be periodically reviewed for appropriateness."
-  impact 0.3
-  tag "rationale": "Reviewing subscriber topics will help ensure that only
+  impact 'low'
+  desc 'rationale', "Reviewing subscriber topics will help ensure that only
 expected recipients receive information published to SNS topics."
   tag "cis_impact": ""
   tag "cis_rid": "3.15"
@@ -18,7 +18,7 @@ expected recipients receive information published to SNS topics."
   tag "csc_control": ""
   tag "nist": ["AC-6", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Perform the following to ensure appropriate subscribers:
+  desc 'check', "Perform the following to ensure appropriate subscribers:
 
 'Via the AWS Management console:
 
@@ -44,7 +44,7 @@ https://console.aws.amazon.com/sns/ [https://console.aws.amazon.com/sns/]
 
 'aws sns list-topics
 aws sns list-subscriptions-by-topic --topic-arn _<topic_arn>_"
-  tag "fix": "Perform the following to remove undesired subscriptions:
+  desc 'fix',"Perform the following to remove undesired subscriptions:
 
 'Via Management Console
 

--- a/controls/cis-aws-foundations-3.2.rb
+++ b/controls/cis-aws-foundations-3.2.rb
@@ -6,8 +6,8 @@ CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for console logins that are not protected by multi-factor
 authentication (MFA)."
-  impact 0.3
-  tag "rationale": "Monitoring for single-factor console logins will increase
+  impact 'low'
+  desc 'rationale', "Monitoring for single-factor console logins will increase
 visibility into accounts that are not protected by MFA."
   tag "cis_impact": ""
   tag "cis_rid": "3.2"
@@ -15,7 +15,7 @@ visibility into accounts that are not protected by MFA."
   tag "csc_control": [["5.5"], "6.0"]
   tag "nist": ["AU-2", "Rev_4"]
   tag "cce_id": "CCE-79187-1"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -38,7 +38,7 @@ contains the following:
 
 ''filterPattern': '{ ($.eventName = 'ConsoleLogin') &'><sns_topic_arn> _
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for AWS Management Console sign-in without MFA and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.3.rb
+++ b/controls/cis-aws-foundations-3.3.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-3.3" do
 CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for root login attempts."
-  impact 0.3
-  tag "rationale": "Monitoring for root account logins will provide visibility
+  impact 'low'
+  desc 'rationale', "Monitoring for root account logins will provide visibility
 into the use of a fully privileged account and an opportunity to reduce the use
 of it."
   tag "cis_impact": ""
@@ -14,7 +14,7 @@ of it."
   tag "csc_control": [["4.6", "5.1","5.5"], "6.0"]
   tag "nist": ["AU-6(5)", "AC-6(9)", "AU-2", "Rev_4"]
   tag "cce_id": "CCE-79188-9"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -38,7 +38,7 @@ contains the following:
 ''filterPattern': '{ $.userIdentity.type = \\'Root\\' &&
 $.userIdentity.invokedBy NOT EXISTS &'><sns_topic_arn> _
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for 'Root' account usage and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.4.rb
+++ b/controls/cis-aws-foundations-3.4.rb
@@ -4,8 +4,8 @@ control "cis-aws-foundations-3.4" do
 CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established changes made to Identity and Access Management (IAM) policies."
-  impact 0.3
-  tag "rationale": "Monitoring changes to IAM policies will help ensure
+  impact 'low'
+  desc 'rationale', "Monitoring changes to IAM policies will help ensure
 authentication and authorization controls remain intact."
   tag "cis_impact": ""
   tag "cis_rid": "3.4"
@@ -13,7 +13,7 @@ authentication and authorization controls remain intact."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79189-7"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -50,7 +50,7 @@ captured in step 5.
 
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for IAM Policy changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.5.rb
+++ b/controls/cis-aws-foundations-3.5.rb
@@ -5,8 +5,8 @@ configuration changes"
 CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for detecting changes to CloudTrail's configurations."
-  impact 0.3
-  tag "rationale": "Monitoring changes to CloudTrail's configuration will help
+  impact 'low'
+  desc 'rationale', "Monitoring changes to CloudTrail's configuration will help
 ensure sustained visibility to activities performed in the AWS account."
   tag "cis_impact": ""
   tag "cis_rid": "3.5"
@@ -14,7 +14,7 @@ ensure sustained visibility to activities performed in the AWS account."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79190-5"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -52,7 +52,7 @@ _<cloudtrail_cfg_changes_metric> _captured in step 5.
 
 'aws sns list-subscriptions-by-topic --topic-arn _<sns_topic_arn> _
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for Cloudtrail configuration changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.6.rb
+++ b/controls/cis-aws-foundations-3.6.rb
@@ -6,7 +6,7 @@ CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for failed console authentication attempts."
   impact 0.7
-  tag "rationale": "Monitoring failed console logins may decrease lead time to
+  desc 'rationale', "Monitoring failed console logins may decrease lead time to
 detect an attempt to brute force a credential, which may provide an indicator,
 such as source IP, that can be used in other event correlation."
   tag "cis_impact": ""
@@ -15,7 +15,7 @@ such as source IP, that can be used in other event correlation."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79191-3"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -39,7 +39,7 @@ contains the following:
 ''filterPattern': '{ ($.eventName = ConsoleLogin) &'><sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for AWS Management Console authentication failures and
 the <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.7.rb
+++ b/controls/cis-aws-foundations-3.7.rb
@@ -7,7 +7,7 @@ filters and alarms. It is recommended that a metric filter and alarm be
 established for customer created CMKs which have changed state to disabled or
 scheduled deletion."
   impact 0.7
-  tag "rationale": "Data encrypted with disabled or deleted keys will no longer
+  desc 'rationale', "Data encrypted with disabled or deleted keys will no longer
 be accessible."
   tag "cis_impact": ""
   tag "cis_rid": "3.7"
@@ -15,7 +15,7 @@ be accessible."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79192-1"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -39,7 +39,7 @@ contains the following:
 ''filterPattern': '{($.eventSource = kms.amazonaws.com) &'><sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for disabled or scheduled for deletion CMK's and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.8.rb
+++ b/controls/cis-aws-foundations-3.8.rb
@@ -5,8 +5,8 @@ changes"
 CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for changes to S3 bucket policies."
-  impact 0.3
-  tag "rationale": "Monitoring changes to S3 bucket policies may reduce time to
+  impact 'low'
+  desc 'rationale', "Monitoring changes to S3 bucket policies may reduce time to
 detect and correct permissive policies on sensitive S3 buckets."
   tag "cis_impact": ""
   tag "cis_rid": "3.8"
@@ -14,7 +14,7 @@ detect and correct permissive policies on sensitive S3 buckets."
   tag "csc_control": ""
   tag "nist": ["SI-4(5)", "Rev_4"]
   tag "cce_id": "CCE-79193-9"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -39,7 +39,7 @@ contains the following:
 
 '
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for S3 Bucket Policy changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-3.9.rb
+++ b/controls/cis-aws-foundations-3.9.rb
@@ -6,7 +6,7 @@ CloudTrail Logs to CloudWatch Logs and establishing corresponding metric
 filters and alarms. It is recommended that a metric filter and alarm be
 established for detecting changes to CloudTrail's configurations."
   impact 0.7
-  tag "rationale": "Monitoring changes to AWS Config configuration will help
+  desc 'rationale', "Monitoring changes to AWS Config configuration will help
 ensure sustained visibility of configuration items within the AWS account."
   tag "cis_impact": ""
   tag "cis_rid": "3.9"
@@ -14,7 +14,7 @@ ensure sustained visibility of configuration items within the AWS account."
   tag "csc_control": [["5.4"], "6.0"]
   tag "nist": ["AC-2(4)", "Rev_4"]
   tag "cce_id": "CCE-79194-7"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed: 1. Identify the log group name configured for use with
 CloudTrail:
 
@@ -38,7 +38,7 @@ contains the following:
 ''filterPattern': '{($.eventSource = config.amazonaws.com) &'><sns_topic_arn> _
 
 "
-  tag "fix": "Perform the following to setup the metric filter, alarm, SNS
+  desc 'fix',"Perform the following to setup the metric filter, alarm, SNS
 topic, and subscription:1. Create a metric filter based on filter pattern
 provided which checks for AWS Config changes and the
 <cloudtrail_log_group_name> taken from audit step 2.

--- a/controls/cis-aws-foundations-4.1.rb
+++ b/controls/cis-aws-foundations-4.1.rb
@@ -5,8 +5,8 @@ control "cis-aws-foundations-4.1" do
   desc  "Security groups provide stateful filtering of ingress/egress network
 traffic to AWS resources. It is recommended that no security group allows
 unrestricted ingress access to port 22."
-  impact 0.3
-  tag "rationale": "Removing unfettered connectivity to remote console
+  impact 'low'
+  desc 'rationale', "Removing unfettered connectivity to remote console
 services, such as SSH, reduces a server's exposure to risk."
   tag "cis_impact": "For updating an existing environment, care should be taken
 to ensure that administrators currently relying on an existing ingress from
@@ -16,7 +16,7 @@ to ensure that administrators currently relying on an existing ingress from
   tag "cis_control_number": ""
   tag "nist": ["SC-7(5)", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed:
 
 * Login to the AWS Management Console at
@@ -33,7 +33,7 @@ Source of 0.0.0.0/0
 Note: A Port value of ALL or a port range such as 0-1024 are inclusive of port
 22.
 "
-  tag "fix": "Perform the following to implement the prescribed state:
+  desc 'fix',"Perform the following to implement the prescribed state:
 
 * Login to the AWS Management Console at
 https://console.aws.amazon.com/vpc/home

--- a/controls/cis-aws-foundations-4.2.rb
+++ b/controls/cis-aws-foundations-4.2.rb
@@ -5,8 +5,8 @@ control "cis-aws-foundations-4.2" do
   desc  "Security groups provide stateful filtering of ingress/egress network
 traffic to AWS resources. It is recommended that no security group allows
 unrestricted ingress access to port 3389."
-  impact 0.3
-  tag "rationale": "Removing unfettered connectivity to remote console
+  impact 'low'
+  desc 'rationale', "Removing unfettered connectivity to remote console
 services, such as RDP, reduces a server's exposure to risk."
   tag "cis_impact": "For updating an existing environment, care should be taken
 to ensure that administrators currently relying on an existing ingress from
@@ -16,7 +16,7 @@ to ensure that administrators currently relying on an existing ingress from
   tag "cis_control_number": ""
   tag "nist": ["SC-7(5)", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed:
 
 * Login to the AWS Management Console at
@@ -33,7 +33,7 @@ Source of 0.0.0.0/0
 Note: A Port value of ALL or a port range such as 1024-4098 are inclusive of
 port 3389.
 "
-  tag "fix": "Perform the following to implement the prescribed state:
+  desc 'fix',"Perform the following to implement the prescribed state:
 
 * Login to the AWS Management Console at
 https://console.aws.amazon.com/vpc/home

--- a/controls/cis-aws-foundations-4.3.rb
+++ b/controls/cis-aws-foundations-4.3.rb
@@ -6,7 +6,7 @@ you've created a flow log, you can view and retrieve its data in Amazon
 CloudWatch Logs. It is recommended that VPC Flow Logs be enabled for packet
 'Rejects' for VPCs."
   impact 0.7
-  tag "rationale": "VPC Flow Logs provide visibility into network traffic that
+  desc 'rationale', "VPC Flow Logs provide visibility into network traffic that
 traverses the VPC and can be used to detect anomalous traffic or insight during
 security workflows."
   tag "cis_impact": "By default, CloudWatch Logs will store Logs indefinitely
@@ -26,7 +26,7 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/SettingLogRete
   tag "cis_control_number": ""
   tag "nist": ["SI-4(4)", "Rev_4"]
   tag "cce_id": "CCE-79202-8"
-  tag "check": "Perform the following to determine if VPC Flow logs is enabled:
+  desc 'check', "Perform the following to determine if VPC Flow logs is enabled:
 
 
 'Via the Management Console:
@@ -37,7 +37,7 @@ http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/SettingLogRete
 * Select a VPC
 * In the right pane, select the Flow Logs tab.
 * Ensure a Log Flow exists that has Active in the Status column."
-  tag "fix": "Perform the following to determine if VPC Flow logs is enabled:
+  desc 'fix',"Perform the following to determine if VPC Flow logs is enabled:
 
 'Via the Management Console:
 

--- a/controls/cis-aws-foundations-4.4.rb
+++ b/controls/cis-aws-foundations-4.4.rb
@@ -22,7 +22,7 @@ this benchmark is not adopted as a permanent security measure, it should be
 used during any period of discovery and engineering for least privileged
 security groups."
   impact 0.7
-  tag "rationale": "Configuring all VPC default security groups to restrict all
+  desc 'rationale', "Configuring all VPC default security groups to restrict all
 traffic will encourage least privilege security group development and mindful
 placement of AWS resources into security groups which will in-turn reduce the
 exposure of those resources."
@@ -37,7 +37,7 @@ for each instance to communicate successfully."
   tag "csc_control": [["9.2"], "6.0"]
   tag "nist": ["SC-7(5)", "Rev_4"]
   tag "cce_id": "CCE-79201-0"
-  tag "check": "Perform the following to determine if the account is configured
+  desc 'check', "Perform the following to determine if the account is configured
 as prescribed:
 
 'Security Group State
@@ -68,7 +68,7 @@ default VPC in each AWS region:
 * Change to the EC2 Management Console at
 https://console.aws.amazon.com/ec2/v2/home
 * In the filter column type 'Security Group ID : <security group id from #4>'"
-  tag "fix": "Security Group Members
+  desc 'fix',"Security Group Members
 
 'Perform the following to implement the prescribed state:
 

--- a/controls/cis-aws-foundations-4.5.rb
+++ b/controls/cis-aws-foundations-4.5.rb
@@ -5,7 +5,7 @@ updated to establish any connections between the peered VPCs. These routes can
 be as specific as desired - even peering a VPC to only a single host on the
 other side of the connection."
   impact 0.7
-  tag "rationale": "Being highly selective in peering routing tables is a very
+  desc 'rationale', "Being highly selective in peering routing tables is a very
 effective way of minimizing the impact of breach as resources outside of these
 routes are inaccessible to the peered VPC."
   tag "cis_impact": ""
@@ -14,7 +14,7 @@ routes are inaccessible to the peered VPC."
   tag "csc_control": ""
   tag "nist": ["SC-7", "Rev_4"]
   tag "cce_id": ""
-  tag "check": "Review routing tables of peered VPCs for whether they route all
+  desc 'check', "Review routing tables of peered VPCs for whether they route all
 subnets of each VPC and whether that is necessary to accomplish the intended
 purposes for peering the VPCs.
 
@@ -27,7 +27,7 @@ is as specific as desired.
 'aws ec2 describe-route-tables --filter 'Name=vpc-id,Values=_<vpc_id>_' --query
 'RouteTables[*].{RouteTableId:RouteTableId, VpcId:VpcId, Routes:Routes,
 AssociatedSubnets:Associations[*].SubnetId}'"
-  tag "fix": "Remove and add route table entries to ensure that the least
+  desc 'fix',"Remove and add route table entries to ensure that the least
 number of subnets or hosts as is required to accomplish the purpose for peering
 are routable.
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,7 +5,7 @@ copyright: MITRE, 2018
 copyright_email: inspec@mitre.org
 license: Apache-2.0
 summary: 'InSpec Profile to validate the CIS AWS Foundations Benchmark v1.1.0'
-version: 1.0.0
+version: 1.1.0
 supports:
   - platform: aws
 inspec_version: "~> 3.0"
@@ -17,7 +17,7 @@ attributes:
 
   - name: aws_regions
     description: 'all aws regions to be inspected'
-    default: 
+    default:
       - us-east-1
       - us-east-2
       - us-west-1
@@ -71,13 +71,13 @@ attributes:
   - name: exception_bucket_list
     description: 'list of buckets exempted from inspection'
     type: array
-    default: 
+    default:
       - exception_bucket_name
 
   - name: config_delivery_channels
     description: 'Config service settings'
     type: hash
-    default: 
+    default:
       us-east-1:
         s3_bucket_name: s3_bucket_name_value
         sns_topic_arn: sns_topic_arn_value
@@ -94,7 +94,7 @@ attributes:
   - name: sns_topics
     description: 'SNS topics list and details'
     type: hash
-    default: 
+    default:
       topic_arn1:
         owner: owner_value
         region: region_value
@@ -105,7 +105,7 @@ attributes:
   - name: sns_subscriptions
     description: 'SNS subscription list and details'
     type: hash
-    default: 
+    default:
       subscription_arn1:
         endpoint: endpoint_value
         owner: owner_value
@@ -118,5 +118,5 @@ attributes:
   - name: exception_security_group_list
     description: 'list of security groups exempted from inspection'
     type: array
-    default: 
+    default:
       - 'exception_security_group_name'


### PR DESCRIPTION
* updated to use text based impacts via CVSS 3.0
* updated to use description sub-sections for rationale, check and fix

Note to implementer:
- we should be able to parse a *mixed* set of data. i.e. they used numbers for impact in some and some text, they used tags in some and sub-sections in other controls etc.
- check and fix should drop into the normal place 
- TBD: all non-default descriptions should be at the end after a new line of the default
- special case: `caveat` sub-section should be placed both at the end of the `results` display as well. We can document this in the readme of heimdall (open issue) and heimdall-lite (open-issue) as a way for folks to document results.

**Blocked from merge** until heimdall and heimdall-lite add the logic to parse both styles.

Fixes #15 #14 
https://github.com/mitre/heimdall-lite/issues/44
https://github.com/aaronlippold/heimdall/issues/72